### PR TITLE
Creates new fleet extension for tab organization in policy editing page

### DIFF
--- a/x-pack/plugins/apm/public/components/fleet_integration/agent_configuration/edit_apm_agent_config.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/agent_configuration/edit_apm_agent_config.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+// import { APMPolicyForm } from '.';
+import {
+  NewPackagePolicy,
+  PackagePolicy,
+  PackagePolicyEditExtensionComponentProps,
+  // PackagePolicyVars,
+} from '../apm_policy_form/typings';
+// import { POLICY_ELASTIC_AGENT_ON_CLOUD } from '../../../../common/fleet';
+
+interface Props {
+  policy: PackagePolicy;
+  newPolicy: NewPackagePolicy;
+  onChange: PackagePolicyEditExtensionComponentProps['onChange'];
+}
+
+export function EditAPMAgentConfig({ newPolicy, onChange }: Props) {
+  // const [firstInput, ...restInputs] = newPolicy?.inputs;
+  // const vars = firstInput?.vars;
+
+  // function handleChange(newVars: PackagePolicyVars, isValid: boolean) {
+  //   onChange({
+  //     isValid,
+  //     updatedPolicy: {
+  //       inputs: [{ ...firstInput, vars: newVars }, ...restInputs],
+  //     },
+  //   });
+  // }
+  return (
+    // <APMPolicyForm
+    //   vars={vars}
+    //   onChange={handleChange}
+    //   isCloudPolicy={newPolicy.policy_id === POLICY_ELASTIC_AGENT_ON_CLOUD}
+    // />
+    <section>
+      <h3>Agent Configuration Settings</h3>
+    </section>
+  );
+}

--- a/x-pack/plugins/apm/public/components/fleet_integration/lazy_apm_agent_config_edit_extension.tsx
+++ b/x-pack/plugins/apm/public/components/fleet_integration/lazy_apm_agent_config_edit_extension.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { lazy } from 'react';
+import { PackagePolicyEditExtensionComponent } from '../../../../fleet/public';
+
+export const getLazyAPMAgentConfigEditExtension = () => {
+  return lazy<PackagePolicyEditExtensionComponent>(async () => {
+    const { EditAPMAgentConfig } = await import(
+      './agent_configuration/edit_apm_agent_config'
+    );
+
+    return { default: EditAPMAgentConfig };
+  });
+};

--- a/x-pack/plugins/apm/public/plugin.ts
+++ b/x-pack/plugins/apm/public/plugin.ts
@@ -50,6 +50,7 @@ import {
 } from './components/fleet_integration';
 import { getLazyAPMPolicyCreateExtension } from './components/fleet_integration/lazy_apm_policy_create_extension';
 import { getLazyAPMPolicyEditExtension } from './components/fleet_integration/lazy_apm_policy_edit_extension';
+import { getLazyAPMAgentConfigEditExtension } from './components/fleet_integration/lazy_apm_agent_config_edit_extension';
 
 export type ApmPluginSetup = ReturnType<ApmPlugin['setup']>;
 
@@ -345,6 +346,17 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
         package: 'apm',
         view: 'package-policy-edit',
         Component: getLazyAPMPolicyEditExtension(),
+      });
+
+      fleet.registerExtension({
+        package: 'apm',
+        view: 'package-policy-edit-tabs',
+        tabs: [
+          {
+            title: 'APM Agents',
+            Component: getLazyAPMAgentConfigEditExtension(),
+          },
+        ],
       });
     }
   }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/layout.tsx
@@ -31,6 +31,11 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
   packageInfo?: PackageInfo;
   integrationInfo?: RegistryPolicyTemplate;
   'data-test-subj'?: string;
+  tabs?: Array<{
+    title: string;
+    isSelected: boolean;
+    onClick: React.ReactEventHandler;
+  }>;
 }> = memo(
   ({
     from,
@@ -41,6 +46,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
     integrationInfo,
     children,
     'data-test-subj': dataTestSubj,
+    tabs = [],
   }) => {
     const pageTitle = useMemo(() => {
       if (
@@ -184,6 +190,7 @@ export const CreatePackagePolicyPageLayout: React.FunctionComponent<{
         rightColumn={rightColumn}
         rightColumnGrow={false}
         data-test-subj={dataTestSubj}
+        tabs={tabs.map(({ title, ...rest }) => ({ name: title, ...rest }))}
       >
         {children}
       </WithHeaderLayout>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -332,30 +332,58 @@ export const EditPackagePolicyForm = memo<{
     }
   };
 
+  const extensionView = useUIExtension(packagePolicy.package?.name ?? '', 'package-policy-edit');
+  const extensionTabsView = useUIExtension(
+    packagePolicy.package?.name ?? '',
+    'package-policy-edit-tabs'
+  );
+  const tabsViews = extensionTabsView?.tabs ?? [];
+  const [selectedTab, setSelectedTab] = useState(0);
+
   const layoutProps = {
     from,
     cancelUrl,
     agentPolicy,
     packageInfo,
+    tabs: tabsViews.length
+      ? [
+          {
+            title: i18n.translate('xpack.fleet.editPackagePolicy.settingsTabName', {
+              defaultMessage: 'Settings',
+            }),
+            isSelected: selectedTab === 0,
+            onClick: () => {
+              setSelectedTab(0);
+            },
+          },
+          ...tabsViews.map(({ title }, index) => ({
+            title,
+            isSelected: selectedTab === index + 1,
+            onClick: () => {
+              setSelectedTab(index + 1);
+            },
+          })),
+        ]
+      : [],
   };
-
-  const extensionView = useUIExtension(packagePolicy.package?.name ?? '', 'package-policy-edit');
 
   const configurePackage = useMemo(
     () =>
       agentPolicy && packageInfo ? (
         <>
-          <StepDefinePackagePolicy
-            agentPolicy={agentPolicy}
-            packageInfo={packageInfo}
-            packagePolicy={packagePolicy}
-            updatePackagePolicy={updatePackagePolicy}
-            validationResults={validationResults!}
-            submitAttempted={formState === 'INVALID'}
-          />
+          {selectedTab === 0 && (
+            <StepDefinePackagePolicy
+              agentPolicy={agentPolicy}
+              packageInfo={packageInfo}
+              packagePolicy={packagePolicy}
+              updatePackagePolicy={updatePackagePolicy}
+              validationResults={validationResults!}
+              submitAttempted={formState === 'INVALID'}
+            />
+          )}
 
           {/* Only show the out-of-box configuration step if a UI extension is NOT registered */}
-          {!extensionView && (
+          {!extensionView && selectedTab === 0 && (
             <StepConfigurePackagePolicy
               packageInfo={packageInfo}
               packagePolicy={packagePolicy}
@@ -370,11 +398,19 @@ export const EditPackagePolicyForm = memo<{
             packagePolicy.package?.name &&
             originalPackagePolicy && (
               <ExtensionWrapper>
-                <extensionView.Component
-                  policy={originalPackagePolicy}
-                  newPolicy={packagePolicy}
-                  onChange={handleExtensionViewOnChange}
-                />
+                {selectedTab === 0 ? (
+                  <extensionView.Component
+                    policy={originalPackagePolicy}
+                    newPolicy={packagePolicy}
+                    onChange={handleExtensionViewOnChange}
+                  />
+                ) : (
+                  React.createElement(tabsViews[selectedTab - 1].Component, {
+                    policy: originalPackagePolicy,
+                    newPolicy: packagePolicy,
+                    onChange: handleExtensionViewOnChange,
+                  })
+                )}
               </ExtensionWrapper>
             )}
         </>
@@ -389,6 +425,7 @@ export const EditPackagePolicyForm = memo<{
       originalPackagePolicy,
       extensionView,
       handleExtensionViewOnChange,
+      selectedTab,
     ]
   );
 

--- a/x-pack/plugins/fleet/public/types/ui_extensions.ts
+++ b/x-pack/plugins/fleet/public/types/ui_extensions.ts
@@ -52,6 +52,16 @@ export interface PackagePolicyEditExtension {
   Component: LazyExoticComponent<PackagePolicyEditExtensionComponent>;
 }
 
+/** Extension point registration contract for Integration Policy Edit tabs views */
+export interface PackagePolicyEditTabsExtension {
+  package: string;
+  view: 'package-policy-edit-tabs';
+  tabs: Array<{
+    title: EuiStepProps['title'];
+    Component: LazyExoticComponent<PackagePolicyEditExtensionComponent>;
+  }>;
+}
+
 /**
  * UI Component Extension is used on the pages displaying the ability to Create an
  * Integration Policy
@@ -120,6 +130,7 @@ export interface AgentEnrollmentFlyoutFinalStepExtension {
 /** Fleet UI Extension Point */
 export type UIExtensionPoint =
   | PackagePolicyEditExtension
+  | PackagePolicyEditTabsExtension
   | PackageCustomExtension
   | PackagePolicyCreateExtension
   | PackageAssetsExtension


### PR DESCRIPTION
APM has a need to organize the package policy edit page into tabs, the normal out-of-box or custom configuration always shows as the first tab, and additional tabs are configured with the `package-policy-edit-tabs` UI Extension Point:

![fleet-policy-edit-tabs-extension](https://user-images.githubusercontent.com/1967266/127676601-09113a9e-b3bc-48d9-94d4-a28a09e75a50.gif)

[x-pack/plugins/apm/public/plugin.ts#L351-L360](https://github.com/cauemarcondes/kibana/pull/1/files#diff-44391dc521f639b32c0d04a77ab21c995adbb13998ee12e41064bde0d23ac234R351-R360) shows how any app can add one or more tabs. The Props interface for the extension Component is the same as the base settings.